### PR TITLE
sed changed to have it correct for grep

### DIFF
--- a/cleanup_friendica.sh
+++ b/cleanup_friendica.sh
@@ -32,7 +32,7 @@ esac
 . /usr/local/etc/cleanup_friendica.conf
 
 # make a list to be used for grep -E 
-protected=$(echo $protectedusers | sed 's/\"//g' | sed 's/\ /\|/g')
+protected=$(echo $protectedusers | sed 's/\"//g' | sed 's/\ /\\\|/g')
 
 cd ${friendicapath} || exit 0
 


### PR DESCRIPTION
Should be like this:
```
grep 'pattern1\|pattern2' filename
```
See: 
https://www.thegeekstuff.com/2011/10/grep-or-and-not-operators/